### PR TITLE
feat: add Swagger API documentation setup and enhance RoutineHistoryS…

### DIFF
--- a/backend/backend/settings.py
+++ b/backend/backend/settings.py
@@ -58,6 +58,7 @@ INSTALLED_APPS = [
     'sales',
     'membership',
     'client_profile',
+    'drf_yasg',
     'routines',
 ]
 

--- a/backend/backend/urls.py
+++ b/backend/backend/urls.py
@@ -2,9 +2,26 @@ from django.contrib import admin
 from django.urls import path
 from django.conf.urls import include
 from dj_rest_auth.views import LoginView, LogoutView
+from django.urls import re_path
+from rest_framework import permissions
+from drf_yasg.views import get_schema_view
+from drf_yasg import openapi
+
 from rest_framework_simplejwt.views import (
     TokenRefreshView,
     TokenVerifyView,
+)
+schema_view = get_schema_view(
+   openapi.Info(
+      title="GymGG API",
+      default_version='v1',
+      description="API para GymGG",
+      terms_of_service="https://www.google.com/policies/terms/",
+      contact=openapi.Contact(email="contact@snippets.local"),
+      license=openapi.License(name="BSD License"),
+   ),
+   public=True,
+   permission_classes=(permissions.AllowAny,),
 )
 urlpatterns = [
 
@@ -15,6 +32,8 @@ urlpatterns = [
     path('api/auth/logout/', LogoutView.as_view(), name='auth_logout'),
     path('api/auth/token/refresh/', TokenRefreshView().as_view(), name='token_refresh'),
     path('api/auth/token/verify/', TokenVerifyView().as_view(), name='token_verify'),
+    path('swagger/', schema_view.with_ui('swagger', cache_timeout=0), name='schema-swagger-ui'),
+    path('redoc/', schema_view.with_ui('redoc', cache_timeout=0), name='schema-redoc'), 
 
     path('products/', include('products.urls')),
     # path('products/categories/', include('products.urls')),

--- a/backend/routines/serializers.py
+++ b/backend/routines/serializers.py
@@ -7,24 +7,35 @@ class ExerciseSerializer(serializers.ModelSerializer):
         fields = '__all__'
 
 class RoutineHistorySerializer(serializers.ModelSerializer):
+    Routine_name = serializers.CharField(source='routine.Routine_name', read_only=True)
+    Description = serializers.CharField(source='routine.Description', read_only=True)
+    Last_time_done = serializers.DateTimeField(source='routine.Last_time_done', read_only=True)
+    Times_done = serializers.IntegerField(source='routine.Times_done', read_only=True)
+    exercises = ExerciseSerializer(source='routine.exercises', many=True, read_only=True)
 
-    
-    # exercises = ExerciseSerializer(many=True, read_only=True)
-
-    # total_time = serializers.SerializerMethodField()
-    # total_minutes = serializers.SerializerMethodField()
+    total_time = serializers.SerializerMethodField()
+    total_minutes = serializers.SerializerMethodField()
 
     class Meta:
         model = RoutineHistory
-        fields = "__all__"
-     
-    
+        fields = [
+            'id',
+            'Routine_name',
+            'Description',
+            'Last_time_done',
+            'Times_done',
+            'exercises',
+            'total_time',      
+            'total_minutes',
+            'Date_realization',
+            'Time_to_done'
+        ]
 
-    # def get_total_time(self, obj):
-    #     return obj.Total_time
+    def get_total_time(self, obj):
+        return obj.routine.Total_time if obj.routine else 0
 
-    # def get_total_minutes(self, obj):
-    #     return obj.tiempo_total_minutos
+    def get_total_minutes(self, obj):
+        return obj.routine.tiempo_total_minutos if obj.routine else 0
 
 
 class RoutinaSerializer(serializers.ModelSerializer):

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,4 @@ djangorestframework-simplejwt
 dj-rest-auth
 django-allauth
 requests
+drf-yasg


### PR DESCRIPTION
Se agregó la documentación automática de la API para que sea más fácil entender y probar los endpoints.
Ahora se puede acceder desde /swagger/ o /redoc/ en el navegador.